### PR TITLE
Merge from the options prop rather than the non existent opts prop.

### DIFF
--- a/compiled/components/fields/select.js
+++ b/compiled/components/fields/select.js
@@ -127,7 +127,7 @@ module.exports = function () {
           });
         }
 
-        options = merge.recursive(options, this.opts);
+        options = merge.recursive(options, this.options);
 
         this.el = $(this.$el).find("select");
 


### PR DESCRIPTION
I couldn't work out how to pass through select2 options, as far as I can tell, this was a bug because the options prop was never merged into the options object passed to select2.